### PR TITLE
Add option to specify models path and do not keep open the results file descriptor

### DIFF
--- a/validation/validate_hanoi.py
+++ b/validation/validate_hanoi.py
@@ -42,7 +42,6 @@ if __name__ == "__main__":
         ts = time.localtime(time.time())
         date_time = '{}_{}_{}-{}_{}_{}'.format(ts[0], ts[1], ts[2], ts[3], ts[4], ts[5])
         results_save_path = '../results/validation_hanoi_npi_{}-{}.txt'.format(date_time, seed)
-        results_file = open(results_save_path, 'w')
 
     # Load environment constants
     env_tmp = HanoiEnv(n=5, encoding_dim=conf.encoding_dim)
@@ -65,7 +64,8 @@ if __name__ == "__main__":
         print('Start validation for model: {}'.format(load_path))
 
     if save_results:
-        results_file.write('Validation on model: {}'.format(load_path) + ' \n')
+        with open(results_save_path, 'a+') as results_file:
+            results_file.write('Validation on model: {}'.format(load_path) + ' \n')
 
     t_i = time.time()
     for n in [2, 3, 4, 5, 10, 12]:
@@ -116,16 +116,12 @@ if __name__ == "__main__":
             str = 'n: {}, mcts mean reward: {}, mcts mean normalized reward: {}, ' \
                   'network only mean reward: {}'.format(n, mcts_rewards_mean, mcts_rewards_normalized_mean,
                                                         network_only_rewards_mean)
-            results_file.write(str + ' \n')
+            with open(results_save_path, 'a+') as results_file:
+                results_file.write(str + ' \n')
 
     t_f = time.time()
     if verbose:
         print('End of Validation!')
         duration = t_f - t_i
         print('Duration: {} minutes'.format(duration / 60))
-
-    if save_results:
-        results_file.close()
-
-
 

--- a/validation/validate_recursive_sorting.py
+++ b/validation/validate_recursive_sorting.py
@@ -42,7 +42,6 @@ if __name__ == "__main__":
         ts = time.localtime(time.time())
         date_time = '{}_{}_{}-{}_{}_{}'.format(ts[0], ts[1], ts[2], ts[3], ts[4], ts[5])
         results_save_path = '../results/validation_recursive_list_npi_{}-{}.txt'.format(date_time, seed)
-        results_file = open(results_save_path, 'w')
 
     # Load environment constants
     env_tmp = RecursiveListEnv(length=5, encoding_dim=conf.encoding_dim)
@@ -64,7 +63,8 @@ if __name__ == "__main__":
         print('Start validation for model: {}'.format(load_path))
 
     if save_results:
-        results_file.write('Validation on model: {}'.format(load_path) + ' \n')
+        with open(results_save_path, "a+") as results_file:
+            results_file.write('Validation on model: {}'.format(load_path) + ' \n')
 
     t_i = time.time()
     for len in [5, 10, 20, 60, 100]:
@@ -112,13 +112,11 @@ if __name__ == "__main__":
             str = 'Length: {}, mcts mean reward: {}, mcts mean normalized reward: {}, ' \
                   'network only mean reward: {}'.format(len, mcts_rewards_mean, mcts_rewards_normalized_mean,
                                                         network_only_rewards_mean)
-            results_file.write(str + ' \n')
+            with open(results_save_path, "a+") as results_file:
+                results_file.write(str + ' \n')
 
     t_f = time.time()
     if verbose:
         print('End of Validation!')
         duration = t_f - t_i
         print('Duration: {} minutes'.format(duration / 60))
-
-    if save_results:
-        results_file.close()

--- a/validation/validate_sorting.py
+++ b/validation/validate_sorting.py
@@ -42,7 +42,6 @@ if __name__ == "__main__":
         ts = time.localtime(time.time())
         date_time = '{}_{}_{}-{}_{}_{}'.format(ts[0], ts[1], ts[2], ts[3], ts[4], ts[5])
         results_save_path = '../results/validation_list_npi_{}-{}.txt'.format(date_time, seed)
-        results_file = open(results_save_path, 'w')
 
     # Load environment constants
     env_tmp = ListEnv(length=5, encoding_dim=conf.encoding_dim)
@@ -65,7 +64,8 @@ if __name__ == "__main__":
         print('Start validation for model: {}'.format(load_path))
 
     if save_results:
-        results_file.write('Validation on model: {}'.format(load_path) + ' \n')
+        with open(results_save_path, "a+") as results_file:
+            results_file.write('Validation on model: {}'.format(load_path) + ' \n')
 
     for len in [5, 10, 20, 60, 100]:
 
@@ -112,10 +112,5 @@ if __name__ == "__main__":
             str = 'Length: {}, mcts mean reward: {}, mcts mean normalized reward: {}, ' \
                   'network only mean reward: {}'.format(len, mcts_rewards_mean, mcts_rewards_normalized_mean,
                                                         network_only_rewards_mean)
-            results_file.write(str + ' \n')
-
-    if save_results:
-        results_file.close()
-
-
-
+            with open(results_save_path, "a+") as results_file:
+                results_file.write(str + ' \n')

--- a/validation/validate_sorting_nohierarchy.py
+++ b/validation/validate_sorting_nohierarchy.py
@@ -45,7 +45,6 @@ if __name__ == "__main__":
         date_time = '{}_{}_{}-{}_{}_{}'.format(ts[0], ts[1], ts[2], ts[3], ts[4], ts[5])
         results_save_path = '../results/validation_list_npi_nohierarchy{}-{}_max_{}_val_{}.txt'
         results_save_path = results_save_path.format(date_time, seed, max, val)
-        results_file = open(results_save_path, 'w')
 
     # Load environment constants
     env_tmp = ListEnv(length=5, encoding_dim=conf.encoding_dim, hierarchy=False)
@@ -68,7 +67,8 @@ if __name__ == "__main__":
         print('Start validation for model: {}'.format(load_path))
 
     if save_results:
-        results_file.write('Validation on model: {}'.format(load_path) + ' \n')
+        with open(results_save_path, "a+") as results_file:
+            results_file.write('Validation on model: {}'.format(load_path) + ' \n')
 
     for len in [3, 4, 5, 6, 7, 8, 9, 10]:
 
@@ -115,10 +115,5 @@ if __name__ == "__main__":
             str = 'Length: {}, mcts mean reward: {}, mcts mean normalized reward: {}, ' \
                   'network only mean reward: {}'.format(len, mcts_rewards_mean, mcts_rewards_normalized_mean,
                                                         network_only_rewards_mean)
-            results_file.write(str + ' \n')
-
-    if save_results:
-        results_file.close()
-
-
-
+            with open(results_save_path, "a+") as results_file:
+                results_file.write(str + ' \n')

--- a/visualization/visualize_hanoi.py
+++ b/visualization/visualize_hanoi.py
@@ -1,3 +1,4 @@
+from argparse import ArgumentParser
 from environments.hanoi_env import HanoiEnv, HanoiEnvEncoder
 from core.policy import Policy
 import core.config as conf
@@ -6,9 +7,12 @@ from core.mcts import MCTS
 from visualization.visualise_mcts import MCTSvisualiser
 
 if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("--load-path", default="../models/hanoi_npi_2019_5_17-11_45_25-1.pth", help="Path to model to visualize")
+    args = parser.parse_args()
 
     # Path to load policy
-    load_path = '../models/hanoi_npi_2019_5_17-11_45_25-1.pth'
+    load_path = args.load_path
 
     # Load environment constants
     env_tmp = HanoiEnv(n=5, encoding_dim=conf.encoding_dim)

--- a/visualization/visualize_recursive_sorting.py
+++ b/visualization/visualize_recursive_sorting.py
@@ -1,3 +1,4 @@
+from argparse import ArgumentParser
 from environments.recursive_list_env import RecursiveListEnv, RecursiveListEnvEncoder
 from core.policy import Policy
 import core.config as conf
@@ -8,10 +9,13 @@ from visualization.visualise_mcts import MCTSvisualiser
 import time
 
 if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("--load-path", default="../models/recursive_list_npi_2019_5_10-15_9_57-1.pth", help="Path to model to visualize")
+    args = parser.parse_args()
 
     # Path to load policy
     #load_path = '../models/recursive_list_npi_2019_5_15-16_9_19-1.pth'
-    load_path = '../models/recursive_list_npi_2019_5_10-15_9_57-1.pth'
+    load_path = args.load_path
 
     # Load environment constants
     env_tmp = RecursiveListEnv(length=5, encoding_dim=conf.encoding_dim)

--- a/visualization/visualize_sorting.py
+++ b/visualization/visualize_sorting.py
@@ -1,3 +1,4 @@
+from argparse import ArgumentParser
 from environments.list_env import ListEnv, ListEnvEncoder
 from core.policy import Policy
 import core.config as conf
@@ -6,10 +7,13 @@ from core.mcts import MCTS
 from visualization.visualise_mcts import MCTSvisualiser
 
 if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("--load-path", default="../models/list_npi_2019_5_13-9_26_38-1.pth", help="Path to model to visualize")
+    args = parser.parse_args()
 
     # Path to load policy
     #load_path = '../models/list_npi_2019_5_16-10_19_59-1.pth'
-    load_path = '../models/list_npi_2019_5_13-9_26_38-1.pth'
+    load_path = args.load_path
 
     # Load environment constants
     env_tmp = ListEnv(length=5, encoding_dim=conf.encoding_dim)

--- a/visualization/visualize_sorting_nohierarchy.py
+++ b/visualization/visualize_sorting_nohierarchy.py
@@ -1,3 +1,4 @@
+from argparse import ArgumentParser
 from environments.list_env import ListEnv, ListEnvEncoder
 from core.policy import Policy
 import core.config as conf
@@ -6,9 +7,12 @@ from core.mcts import MCTS
 from visualization.visualise_mcts import MCTSvisualiser
 
 if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("--load-path", default="../models/list_npi_nohierarchy_2019_5_21-15_28_47-3_max_4_val_4.pth", help="Path to model to visualize")
+    args = parser.parse_args()
 
     # Path to load policy
-    load_path = "../models/list_npi_nohierarchy_2019_5_21-15_28_47-3_max_4_val_4.pth"
+    load_path = args.load_path
 
     # Load environment constants
     env_tmp = ListEnv(length=5, encoding_dim=conf.encoding_dim, hierarchy=False)


### PR DESCRIPTION
Good Afternoon,
I noticed that if the training is done on a slow machine keeping the results file descriptor open for the whole training lead to corrupted files so now the file is opened and closed only when needed. Also I added a command line argument to visualization scripts to specify a model path.